### PR TITLE
[Feature] Created status/keys manipulation handles

### DIFF
--- a/src/api/admin-api/admin-api.controller.ts
+++ b/src/api/admin-api/admin-api.controller.ts
@@ -1,13 +1,12 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { MethodNotAllowedException } from '@nestjs/common/exceptions';
 import { UsersService } from '../../core/users/users.service';
 import { NewAdminDto } from './dto/new-admin.dto';
 import { UserRole } from '../../common/types/user.types';
-import { Public } from '../../common/decorators/public.decorator';
 import { AccessControlGuard } from '../../common/guards/access-control.guard';
-import { Root } from '../../common/decorators/root.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
-import { Role } from '../../common/decorators/roles.decorator';
 import { AccessControlList } from '../../common/decorators/access-control-list.decorator';
+import { AccessRights } from '../../common/types/access-rights.types';
 
 @UseGuards(JwtAuthGuard)
 @UseGuards(AccessControlGuard)
@@ -15,9 +14,7 @@ import { AccessControlList } from '../../common/decorators/access-control-list.d
 export class AdminApiController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Post('new')
-  // @Role(UserRole.ADMIN)
-  // @Root()
+  @Post('create')
   @AccessControlList({ role: UserRole.ADMIN, isRoot: true })
   async create(@Body() dto: NewAdminDto) {
     return this.usersService.createAdmin({
@@ -26,5 +23,55 @@ export class AdminApiController {
       permissions: [],
       isRoot: false,
     });
+  }
+
+  @Put(':id/activate')
+  @AccessControlList({ role: UserRole.ADMIN, isRoot: true })
+  async activate(@Param(':id') _id: string) {
+    return this.usersService.activate(_id);
+  }
+
+  @Delete(':id/activate')
+  @AccessControlList({ role: UserRole.ADMIN, isRoot: true })
+  async deactivate(@Param(':id') _id: string) {
+    return this.usersService.deactivate(_id);
+  }
+
+  @Put('/:id/confirm')
+  @AccessControlList({ role: UserRole.ADMIN, rights: [AccessRights.confirmUser] })
+  async confirm(@Param(':id') _id: string) {
+    return this.usersService.confirm(_id);
+  }
+
+  @Delete('/:id/confirm')
+  @AccessControlList({ role: UserRole.ADMIN, rights: [AccessRights.blockUser] })
+  async block(@Param(':id') _id: string) {
+    return this.usersService.block(_id);
+  }
+
+  @Put('/:id/promote')
+  @AccessControlList({ role: UserRole.ADMIN, rights: [AccessRights.promoteUser] })
+  async upgrade(@Param(':id') _id: string) {
+    return this.usersService.upgrade(_id);
+  }
+
+  @Delete('/:id/promote')
+  @AccessControlList({ role: UserRole.ADMIN, isRoot: true })
+  async downgrade(@Param(':id') _id: string) {
+    throw new MethodNotAllowedException('Этот метод нельзя использовать здесь!');
+    // return this.usersService.downgrade(_id);
+  }
+
+  @Put('/:id/keys')
+  @AccessControlList({ role: UserRole.ADMIN, rights: [AccessRights.giveKey] })
+  async cgrantKeys(@Param(':id') _id: string) {
+    return this.usersService.grantKeys(_id);
+  }
+
+  @Delete('/:id/keys')
+  @AccessControlList({ role: UserRole.ADMIN, isRoot: true })
+  async revokeKeys(@Param(':id') _id: string) {
+    throw new MethodNotAllowedException('Этот метод нельзя использовать здесь!');
+    //  return this.usersService.revokeKeys(_id);
   }
 }

--- a/src/api/admin-api/admin-api.controller.ts
+++ b/src/api/admin-api/admin-api.controller.ts
@@ -64,7 +64,7 @@ export class AdminApiController {
 
   @Put('/:id/keys')
   @AccessControlList({ role: UserRole.ADMIN, rights: [AccessRights.giveKey] })
-  async cgrantKeys(@Param(':id') _id: string) {
+  async grantKeys(@Param(':id') _id: string) {
     return this.usersService.grantKeys(_id);
   }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { AuthModule } from './core/auth/auth.module';
 import { UsersModule } from './core/users/users.module';
 import { MongooseConfigService } from './config/database-config.service';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
+import { AdminApiModule } from './api/admin-api/admin-api.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
     AuthApiModule,
     AuthModule,
     UsersModule,
+    AdminApiModule,
   ],
   providers: [
     {

--- a/src/common/types/user.types.ts
+++ b/src/common/types/user.types.ts
@@ -43,9 +43,7 @@ export enum ResolveStatus {
 }
 
 export type UserProfile = {
-  firstName: string;
-  middleName: string;
-  lastName: string;
+  name: string;
   phone: string;
   avatar: string;
   address: string;
@@ -53,9 +51,7 @@ export type UserProfile = {
 };
 
 export interface GenericUserModelInterface {
-  firstName: string;
-  middleName: string;
-  lastName: string;
+  name: string;
   phone: string;
   avatar: string;
   address: string;
@@ -80,6 +76,7 @@ export interface AdminUserModelInterface {
   login: string;
   password: string;
   isRoot: boolean;
+  isActive: boolean;
 }
 
 export interface VolunteerInterface

--- a/src/common/types/user.types.ts
+++ b/src/common/types/user.types.ts
@@ -12,6 +12,7 @@ import { AccessRights } from './access-rights.types';
 }; */
 
 export enum UserStatus {
+  BLOCKED = -1,
   UNCONFIRMED = 0,
   CONFIRMED = 1,
   VERIFIED = 2,

--- a/src/core/tasks/tasks.service.ts
+++ b/src/core/tasks/tasks.service.ts
@@ -1,4 +1,119 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { FilterQuery } from 'mongoose';
+import { TasksRepository } from '../../datalake/task/task.repository';
+import { UsersRepository } from '../../datalake/users/users.repository';
+import { CreateTaskDto, GetVirginTasksDto } from '../../common/dto/tasks.dto';
+import { Recipient } from '../../datalake/users/schemas/recipient.schema';
+import { Admin } from '../../datalake/users/schemas/admin.schema';
+import { CategoryRepository } from '../../datalake/category/category.repository';
+import { Task } from '../../datalake/task/schemas/task.schema';
+import { ResolveStatus } from '../../common/types/task.types';
 
 @Injectable()
-export class TasksService {}
+export class TasksService {
+  constructor(
+    private readonly tasksRepo: TasksRepository,
+    private readonly usersRepo: UsersRepository,
+    private readonly categoryRepo: CategoryRepository
+  ) {}
+
+  public async create(dto: CreateTaskDto) {
+    const { recipientId, categoryId, ...data } = dto;
+    /*   const [recipient, category] = Promise.all<
+      [(User & Recipient) | (User & Volunteer) | (User & Admin), Category]
+        >(
+    [this.usersRepo.findById(recipientId), this.categoryRepo.findById(categoryId)]); */
+    const recipient = await this.usersRepo.findById(recipientId);
+    const category = await this.categoryRepo.findById(categoryId);
+    if (!(recipient instanceof Recipient || recipient instanceof Admin)) {
+      throw new ForbiddenException('Только реципиент или администратор могут создавать заявки', {
+        cause: `Попытка создать заявку пользователем с _id ${recipientId} и ролью волонтёра`,
+      });
+    }
+    const { name, phone, avatar, address, _id } = recipient;
+    const task = {
+      ...data,
+      recipient: { name, phone, avatar, address, _id },
+      volunteer: null,
+      category,
+      isPendingChanges: false,
+    };
+    return this.tasksRepo.create(task);
+  }
+
+  public async getVirginTasks(dto: GetVirginTasksDto) {
+    const {
+      location: { coordinates: center },
+      distance,
+      start,
+      end,
+      categoryId,
+    } = dto;
+    const query: FilterQuery<Task> = {
+      volunteerReport: ResolveStatus.VIRGIN,
+      recipientReport: ResolveStatus.VIRGIN,
+      location: {
+        $near: {
+          $geometry: center,
+          $maxDistance: distance,
+        },
+      },
+    };
+    if (categoryId) {
+      query.category = await this.categoryRepo.findById(categoryId);
+    }
+    if (!!start && !!end) {
+      query.date = {
+        $gte: start,
+        $lte: end,
+      };
+    } else if (!!start && !end) {
+      query.date = {
+        $gte: start,
+      };
+    } else if (!start && !!end) {
+      query.date = {
+        $lte: end,
+      };
+    }
+    return this.tasksRepo.find(query);
+  }
+
+  public async getAcceptedTasks(dto: GetVirginTasksDto) {
+    const {
+      location: { coordinates: center },
+      distance,
+      start,
+      end,
+      categoryId,
+    } = dto;
+    const query: FilterQuery<Task> = {
+      volunteerReport: ResolveStatus.VIRGIN,
+      recipientReport: ResolveStatus.VIRGIN,
+      location: {
+        $near: {
+          $geometry: center,
+          $maxDistance: distance,
+        },
+      },
+    };
+    if (categoryId) {
+      query.category = await this.categoryRepo.findById(categoryId);
+    }
+    if (!!start && !!end) {
+      query.date = {
+        $gte: start,
+        $lte: end,
+      };
+    } else if (!!start && !end) {
+      query.date = {
+        $gte: start,
+      };
+    } else if (!start && !!end) {
+      query.date = {
+        $lte: end,
+      };
+    }
+    return this.tasksRepo.find(query);
+  }
+}

--- a/src/core/tasks/tasks.service.ts
+++ b/src/core/tasks/tasks.service.ts
@@ -19,10 +19,6 @@ export class TasksService {
 
   public async create(dto: CreateTaskDto) {
     const { recipientId, categoryId, ...data } = dto;
-    /*   const [recipient, category] = Promise.all<
-      [(User & Recipient) | (User & Volunteer) | (User & Admin), Category]
-        >(
-    [this.usersRepo.findById(recipientId), this.categoryRepo.findById(categoryId)]); */
     const recipient = await this.usersRepo.findById(recipientId);
     const category = await this.categoryRepo.findById(categoryId);
     if (!(recipient instanceof Recipient || recipient instanceof Admin)) {

--- a/src/datalake/users/schemas/admin.schema.ts
+++ b/src/datalake/users/schemas/admin.schema.ts
@@ -39,6 +39,13 @@ export class Admin extends Document implements AdminUserModelInterface {
     immutable: true,
   })
   isRoot: boolean;
+
+  @Prop({
+    required: true,
+    type: SchemaTypes.Boolean,
+    default: false,
+  })
+  isActive: boolean;
 }
 
 export const AdminUserSchema = SchemaFactory.createForClass<AdminUserModelInterface>(Admin);

--- a/src/datalake/users/schemas/user.schema.ts
+++ b/src/datalake/users/schemas/user.schema.ts
@@ -11,14 +11,7 @@ import { GenericUserModelInterface, UserRole } from '../../../common/types/user.
     virtuals: true,
     flattenObjectIds: true,
   },
-  virtuals: {
-    fullName: {
-      get() {
-        return `${this.firstName ? this.firstName : ''} ${this.middleName ? this.firstName : ''}  ${
-          this.lastName ? this.lastName : ''
-        }`;
-      },
-    },
+  /* virtuals: {
     profile: {
       get() {
         return {
@@ -32,7 +25,7 @@ import { GenericUserModelInterface, UserRole } from '../../../common/types/user.
         };
       },
     },
-  },
+  }, */
 })
 export class User extends Document implements GenericUserModelInterface {
   @Prop({ required: true, type: mongoose.SchemaTypes.String })
@@ -42,13 +35,7 @@ export class User extends Document implements GenericUserModelInterface {
   avatar: string;
 
   @Prop({ required: true, type: mongoose.SchemaTypes.String })
-  firstName: string;
-
-  @Prop({ required: true, type: mongoose.SchemaTypes.String })
-  lastName: string;
-
-  @Prop({ required: true, type: mongoose.SchemaTypes.String })
-  middleName: string;
+  name: string;
 
   @Prop({ required: true, type: mongoose.SchemaTypes.String })
   phone: string;


### PR DESCRIPTION
admin-api handles to grant/revoke keys (`/admin/:id/keys`), activate/deactivate admins (`/admin/:id/activate`) & confirm or block users (`/admin/:id/confirm`). Allow action (grant keys, confirm or activate) by PUT request, contrary (revoke keys, block or deactivate) by DELETE request.