### PR TITLE
[Fix] Made server send 401 on non-existing admin.

### DIFF
--- a/src/core/auth/strategies/local.strategy.ts
+++ b/src/core/auth/strategies/local.strategy.ts
@@ -2,8 +2,7 @@ import { Strategy } from 'passport-local';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { UsersService } from '../../users/users.service';
-import { Admin } from '../../../datalake/users/schemas/admin.schema';
-import { AdminInterface } from 'src/common/types/user.types';
+import { AdminInterface } from '../../../common/types/user.types';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -11,7 +10,10 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     super({ usernameField: 'login' });
   }
 
-  async validate(username: string, password: string): Promise<Record<string, unknown> | AdminInterface> {
+  async validate(
+    username: string,
+    password: string
+  ): Promise<Record<string, unknown> | AdminInterface> {
     const user = await this.userService.checkAdminCredentials(username, password);
     if (!user) {
       throw new UnauthorizedException('Некорректная пара логин и пароль');

--- a/src/core/users/users.service.ts
+++ b/src/core/users/users.service.ts
@@ -3,6 +3,7 @@ import {
   ConflictException,
   ForbiddenException,
   Injectable,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common/exceptions';
 import { UsersRepository } from '../../datalake/users/users.repository';
@@ -73,6 +74,9 @@ export class UsersService {
         isActive: true,
       }
     );
+    if (!user) {
+      throw new UnauthorizedException('Неверное имя пользователя или пароль');
+    }
     const { password: passDb, ...data } = user as AdminInterface;
     const isOk = await HashService.compareHash(password, passDb);
     return isOk ? Promise.resolve(data as AdminInterface) : null;


### PR DESCRIPTION
Added check if admin is found in `checkAdminCredentials()`, so now there will be 401 on both wrong login & pass. And fixed several import as well.