### PR TITLE
Refactor/tasks/account points and tasks for volunteer

### DIFF
--- a/src/common/types/task.types.ts
+++ b/src/common/types/task.types.ts
@@ -50,3 +50,22 @@ export interface TaskInterface {
 export interface TaskModelVirtuals {
   status: TaskStatus;
 }
+
+export interface TaskClosingProps {
+  taskId: string;
+}
+
+export interface FulfilledTaskClosingProps extends TaskClosingProps {
+  volunteerId: string;
+  categoryPoints: number;
+}
+
+export type TaskClosingConditionalProps =
+  | {
+      adminResolveResult?: ResolveResult;
+      userIndex?: never;
+    }
+  | {
+      adminResolveResult?: never;
+      userIndex?: string;
+    };

--- a/src/common/types/user.types.ts
+++ b/src/common/types/user.types.ts
@@ -60,6 +60,7 @@ export interface VolunteerUserModelInterface {
   status: UserStatus;
   location: PointGeoJSONInterface;
   keys: boolean;
+  tasksCompleted: number;
 }
 
 export interface RecipientUserModelInterface {

--- a/src/core/tasks/tasks.module.ts
+++ b/src/core/tasks/tasks.module.ts
@@ -3,9 +3,10 @@ import { TasksService } from './tasks.service';
 import { TasksRepositoryModule } from '../../datalake/task/tasks-repository.module';
 import { UsersRepositoryModule } from '../../datalake/users/users-repository.module';
 import { CategoryRepositoryModule } from '../../datalake/category/category-repository.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TasksRepositoryModule, UsersRepositoryModule, CategoryRepositoryModule],
+  imports: [TasksRepositoryModule, UsersRepositoryModule, CategoryRepositoryModule, UsersModule],
   providers: [TasksService],
   exports: [TasksService],
 })

--- a/src/core/tasks/tasks.service.ts
+++ b/src/core/tasks/tasks.service.ts
@@ -367,11 +367,14 @@ export class TasksService {
       });
     }
 
+    const newScore: number = volunteer.score + categoryPoints;
+    const newTasksComleted: number = volunteer.tasksCompleted + 1;
+
     const updatedVolonteer = (await this.usersRepo.findByIdAndUpdate(
       volunteerId,
       {
-        score: volunteer.score + categoryPoints,
-        tasksCompleted: volunteer.tasksCompleted + 1,
+        score: newScore,
+        tasksCompleted: newTasksComleted,
       },
       { new: true }
     )) as User & Volunteer;

--- a/src/core/tasks/tasks.service.ts
+++ b/src/core/tasks/tasks.service.ts
@@ -376,7 +376,7 @@ export class TasksService {
         score: newScore || volunteer.score,
         tasksCompleted: newTasksComleted,
       },
-      { new: true, overwriteDiscriminatorKey: true }
+      { new: true }
     )) as User & Volunteer;
 
     if (!updatedVolonteer) {

--- a/src/core/tasks/tasks.service.ts
+++ b/src/core/tasks/tasks.service.ts
@@ -370,13 +370,13 @@ export class TasksService {
     const newScore: number = volunteer.score + categoryPoints;
     const newTasksComleted: number = volunteer.tasksCompleted + 1;
 
-    const updatedVolonteer = (await this.usersRepo.findByIdAndUpdate(
-      volunteerId,
+    const updatedVolonteer = (await this.usersRepo.findOneAndUpdate(
+      { _id: volunteerId, role: volunteer.role },
       {
-        score: newScore,
+        score: newScore || volunteer.score,
         tasksCompleted: newTasksComleted,
       },
-      { new: true }
+      { new: true, overwriteDiscriminatorKey: true }
     )) as User & Volunteer;
 
     if (!updatedVolonteer) {

--- a/src/core/users/users.service.ts
+++ b/src/core/users/users.service.ts
@@ -10,6 +10,7 @@ import { UsersRepository } from '../../datalake/users/users.repository';
 import { CreateAdminDto, CreateUserDto } from '../../common/dto/users.dto';
 import {
   AdminInterface,
+  VolunteerInterface,
   AdminPermission,
   UserProfile,
   UserRole,
@@ -326,6 +327,15 @@ export class UsersService {
 
   public async updateProfile(userId: string, dto: Partial<UserProfile>) {
     return this.usersRepo.findByIdAndUpdate(userId, dto, { new: true });
+  }
+
+  public async updateVolunteerProfile(
+    userId: string,
+    dto: Partial<VolunteerInterface>
+  ): Promise<User & Volunteer> {
+    return this.usersRepo.findOneAndUpdate({ _id: userId, role: UserRole.VOLUNTEER }, dto, {
+      new: true,
+    }) as Promise<User & Volunteer>;
   }
 
   private static requireLogin(userId: string) {

--- a/src/datalake/users/schemas/volunteer.schema.ts
+++ b/src/datalake/users/schemas/volunteer.schema.ts
@@ -32,6 +32,9 @@ export class Volunteer extends Document implements VolunteerUserModelInterface {
 
   @Prop({ required: false, default: false, type: SchemaTypes.Boolean })
   keys: boolean;
+
+  @Prop({ type: SchemaTypes.Number, required: true, default: 0 })
+  tasksCompleted: number;
 }
 
 export const VolunteerUserSchema =

--- a/src/datalake/users/schemas/volunteer.schema.ts
+++ b/src/datalake/users/schemas/volunteer.schema.ts
@@ -33,7 +33,7 @@ export class Volunteer extends Document implements VolunteerUserModelInterface {
   @Prop({ required: false, default: false, type: SchemaTypes.Boolean })
   keys: boolean;
 
-  @Prop({ type: SchemaTypes.Number, required: true, default: 0 })
+  @Prop({ type: SchemaTypes.Number, default: 0 })
   tasksCompleted: number;
 }
 


### PR DESCRIPTION
Привет!
- [x] Ввела в схему волонтёра поле `tasksCompleted` типа `number` со значением по умолчанию `0`;
- [x] В сервисе задач создала **приватный** метод завершения заявки как выполненной, который должен:
   - закрывать саму заявку как _успешно_ _выполненную_ ;
   - начислять (прибавлять к имеющимся) волонтёру баллы (количество баллов определяется категорией выполненной задачи);
   - увеличивать счётчик успешных задач у волонтёра на единицу.
   
   _По последним двум пунктам - не могу понять почему, но не отрабатывает обновление информации о волонтере. Возвращает объект, всё ок, БД никакой ошибки не выдает, но значения в score и tasksCompleted не меняются. Может упускаю что-то очевидное и сможете мне подсказать)_ **(update: проблема решена)**

- [x] В сервисе  задач создала **приватный** метод  завершения заявки как *не выполненной*, **без начисления баллов и увеличения счётчика** .
- [x] Перевела имеющиеся публичные методы (reportTask и resolveConflict) на использование выше созданных приватных методов вместо прямого обращения к репозиториям.
- [x] Проверила правильность работы функционала.