### PR TITLE
refactor: replace npm uuid with native nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "socket.io": "^4.7.2",
-        "typeorm": "^0.3.17",
-        "uuid": "^9.0.0"
+        "typeorm": "^0.3.17"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "socket.io": "^4.7.2",
-    "typeorm": "^0.3.17",
-    "uuid": "^9.0.0"
+    "typeorm": "^0.3.17"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/config/multer-config.ts
+++ b/src/config/multer-config.ts
@@ -1,7 +1,7 @@
 import { extname } from 'path';
 import { existsSync, mkdirSync } from 'fs';
 import { diskStorage } from 'multer';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'node:crypto';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import configuration from './configuration';
 


### PR DESCRIPTION
Микро замена. У ноды уже давно свой uuid генератор, зачем плодить лишние зависимости?