### PR TITLE
Реализация Pipe для валидации сокета (задача #141)

### DIFF
--- a/src/common/pipes/socket-validation.pipe.ts
+++ b/src/common/pipes/socket-validation.pipe.ts
@@ -1,0 +1,26 @@
+import { Injectable, ValidationPipe, ValidationPipeOptions } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { ValidationError } from 'class-validator';
+
+@Injectable()
+export class SocketValidationPipe extends ValidationPipe {
+  constructor(options?: ValidationPipeOptions) {
+    super({
+      exceptionFactory: (errors: ValidationError[]): WsException => {
+        if (this.isDetailedOutputDisabled) {
+          return new WsException({
+            message: 'Bad request',
+          });
+        }
+        // eslint-disable-next-line no-console
+        console.log('validationErrors:', errors);
+        return new WsException(errors);
+      },
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      forbidUnknownValues: true,
+      ...options,
+    });
+  }
+}

--- a/src/core/blog/blog.service.ts
+++ b/src/core/blog/blog.service.ts
@@ -8,7 +8,7 @@ export class BlogService {
   constructor(
     private readonly blogRepo: BlogPostRepository,
     private readonly userRepo: UsersRepository
-  ) { }
+  ) {}
 
   async create(dto: Partial<PostDTO>, user) {
     const { name, phone, avatar, address, _id } = user;


### PR DESCRIPTION
@INextYP, @kspshnik 
Привет!
По задаче [#141](https://github.com/orgs/ya-pomogau/projects/1/views/1?pane=issue&itemId=72573020):
- [x] реализовала `SocketValidationPipe`, которая будет валидировать входящие DTO;
- [x] внедрила `SocketValidationPipe` в `SystemApiGateway`;
- [x] добавила тестовую dto-шку, чтобы можно было протестировать пайпу на `test_event`.

В `SocketValidationPipe ` оставила `console.log('validationErrors:', errors)`, так как выброс исключения сейчас никак себя не проявляет. В дальнейшем будем добавлять какой-нибудь `SocketExceptionsFilter` и/или обработчик типа `handleErrorEvent`? Или моя реализация пайпы недостаточна и нужно доработать, чтобы корректно отрабатывал выброс исключения?)