### PR TITLE
feat: prepare gateway for concurrently development

### DIFF
--- a/src/api/websocket-api/websocket-api.gateway.ts
+++ b/src/api/websocket-api/websocket-api.gateway.ts
@@ -15,6 +15,10 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { IsArray, IsNotEmpty, IsObject, IsString } from 'class-validator';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+
+import configuration from '../../config/configuration';
 import { SocketAuthGuard } from '../../common/guards/socket-auth.guard';
 import { SocketValidationPipe } from '../../common/pipes/socket-validation.pipe';
 import { AnyUserInterface } from '../../common/types/user.types';
@@ -24,6 +28,7 @@ import {
   wsConnectedUserData,
   wsDisconnectionPayload,
   wsTokenPayload,
+  wsOpenedChatsData,
 } from '../../common/types/websockets.types';
 
 // Интерфейс и dto созданы для тестирования SocketValidationPipe
@@ -49,7 +54,7 @@ class TestEventMessageDto implements TestEventMessageInterface {
 
 @UseGuards(SocketAuthGuard)
 @UsePipes(SocketValidationPipe)
-@WebSocketGateway({
+@WebSocketGateway(configuration().server.ws_port, {
   cors: {
     allowedHeaders: '*',
   },
@@ -67,6 +72,8 @@ export class WebsocketApiGateway
 
   private connectedUsers: Map<string, wsConnectedUserData> = new Map();
 
+  private openedChats: Map<string, wsOpenedChatsData<string>> = new Map();
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   afterInit(server: Server) {
     // eslint-disable-next-line no-console
@@ -81,30 +88,24 @@ export class WebsocketApiGateway
    */
   // eslint-disable-next-line consistent-return
   async handleConnection(@ConnectedSocket() client: Socket): Promise<void> {
-    let user: AnyUserInterface;
-    try {
-      user = await this.jwtService.verifyAsync(client.handshake.headers.authorization, {
-        secret: this.configService.get<string>('jwt.key'),
-      });
-    } catch (error) {
-      return this.disconnect(client, { type: UnauthorizedException.name, message: error.message });
-    }
+    const user = await this.checkUserAuth(client);
     // eslint-disable-next-line no-console
     console.log('user:', user);
 
-    if (this.connectedUsers.has(user._id)) {
-      const currentSockets = this.connectedUsers.get(user._id).sockets;
-      this.connectedUsers.set(user._id, { user, sockets: [...currentSockets, client.id] });
+    const connectedUser = this.getConnectedUser(user._id);
+    if (connectedUser) {
+      this.connectedUsers.set(user._id, { user, sockets: [...connectedUser.sockets, client.id] });
+    } else {
+      this.connectedUsers.set(user._id, { user, sockets: [client.id] });
     }
-    this.connectedUsers.set(user._id, { user, sockets: [client.id] });
   }
 
   sendTokenAndUpdatedUser(user: AnyUserInterface, token: string) {
-    const connectedUserData: wsConnectedUserData = this.connectedUsers.get(user._id);
+    const connectedUser = this.getConnectedUser(user._id);
 
     // если пользователь подключен, то отправляем токен на все устройства, с которых залогинен
-    if (connectedUserData) {
-      connectedUserData.sockets.forEach((clientId) => {
+    if (connectedUser) {
+      connectedUser.sockets.forEach((clientId) => {
         this.server.sockets.sockets.get(clientId).emit(wsMessageKind.REFRESH_TOKEN_COMMAND, {
           data: {
             user,
@@ -114,32 +115,46 @@ export class WebsocketApiGateway
       });
 
       // обновление объекта подключенного пользователя
-      this.connectedUsers.set(user._id, { user, ...connectedUserData });
+      this.connectedUsers.set(user._id, { user, sockets: [...connectedUser.sockets] });
     }
   }
 
   async handleDisconnect(@ConnectedSocket() client: Socket) {
-    const user: AnyUserInterface = await this.jwtService.verifyAsync(
-      client.handshake.headers.authorization,
-      {
-        secret: this.configService.get<string>('jwt.key'),
+    const user = await this.checkUserAuth(client);
+
+    const connectedUser = this.getConnectedUser(user._id);
+    if (connectedUser) {
+      const sockets = connectedUser.sockets.filter((socket) => socket !== client.id);
+      if (sockets.length > 0) {
+        this.connectedUsers.set(user._id, { user, sockets });
+      } else {
+        this.connectedUsers.delete(user._id);
+
+        client.broadcast.emit(wsMessageKind.DISCONNECTION_EVENT, {
+          data: {
+            userId: user._id,
+          } as wsDisconnectionPayload,
+        } as wsMessageData);
       }
-    );
-
-    client.broadcast.emit(wsMessageKind.DISCONNECTION_EVENT, {
-      data: {
-        userId: user._id,
-      } as wsDisconnectionPayload,
-    } as wsMessageData);
-
-    const sockets = this.connectedUsers
-      .get(user._id)
-      .sockets.filter((socket) => socket !== client.id);
-
-    if (sockets.length > 0) {
-      this.connectedUsers.set(user._id, { user, sockets });
     }
-    this.connectedUsers.delete(user._id);
+  }
+
+  private async checkUserAuth(client: Socket): Promise<AnyUserInterface | null> {
+    let user: AnyUserInterface;
+    try {
+      user = await this.jwtService.verifyAsync(client.handshake.headers.authorization, {
+        secret: this.configService.get<string>('jwt.key'),
+      });
+    } catch (error) {
+      this.disconnect(client, { type: UnauthorizedException.name, message: error.message });
+    }
+
+    return user || null;
+  }
+
+  private getConnectedUser(userId: string): wsConnectedUserData | null {
+    const connectedUser = this.connectedUsers.get(userId);
+    return connectedUser || null;
   }
 
   private disconnect(socket: Socket, error: Record<string, unknown>) {

--- a/src/common/types/websockets.types.ts
+++ b/src/common/types/websockets.types.ts
@@ -58,3 +58,7 @@ export type wsConnectedUserData = {
   user: AnyUserInterface;
   sockets: Array<string>;
 };
+
+export type wsOpenedChatsData<T extends string> = {
+  [key in T]: Array<string>;
+};

--- a/src/core/chat/chats.service.ts
+++ b/src/core/chat/chats.service.ts
@@ -2,18 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import mongoose, { ObjectId } from 'mongoose';
 
-import { ConflictChatsTupleMetaInterface,
+import {
+  ConflictChatsTupleMetaInterface,
   MessageInterface,
   RecipientConflictChatMetaInterface,
   SystemChatMetaInterface,
   TaskChatMetaInterface,
-  VolunteerConflictChatMetaInterface
-} from 'src/common/types/chats.types';
-import { AdminInterface, UserRole, UserStatus } from 'src/common/types/user.types';
-import { wsChatPageQueryPayload, wsMessageData } from 'src/common/types/websockets.types';
+  VolunteerConflictChatMetaInterface,
+} from '../../common/types/chats.types';
+import { AdminInterface, UserRole, UserStatus } from '../../common/types/user.types';
+import { wsChatPageQueryPayload } from '../../common/types/websockets.types';
 
-
-//#region Mock data
+// #region Mock data
 
 const mockVolunteer = {
   _id: 'volunteerId',
@@ -35,7 +35,7 @@ const mockVolunteer = {
   password: 'password',
   isRoot: false,
   isActive: false,
-}
+};
 
 const mockRecipient = {
   _id: 'recepientId',
@@ -57,7 +57,7 @@ const mockRecipient = {
   password: 'password',
   isRoot: false,
   isActive: false,
-}
+};
 
 const mockAdmin: AdminInterface = {
   _id: 'recepientId',
@@ -74,36 +74,40 @@ const mockAdmin: AdminInterface = {
   password: 'password',
   isRoot: false,
   isActive: false,
-}
-
-
+};
 
 const mockMessages = [
   {
     _id: new mongoose.Types.ObjectId().toHexString(),
     title: 'TestTitle1',
     body: 'TestBody1',
-    attaches: [new mongoose.Types.ObjectId().toHexString(), new mongoose.Types.ObjectId().toHexString()],
+    attaches: [
+      new mongoose.Types.ObjectId().toHexString(),
+      new mongoose.Types.ObjectId().toHexString(),
+    ],
     createdAt: new Date(),
     author: mockVolunteer,
     chatId: new mongoose.Types.ObjectId().toHexString(),
   },
   {
-    _id: new mongoose.Types.ObjectId,
+    _id: new mongoose.Types.ObjectId().toHexString(),
     title: 'TestTitle2',
     body: 'TestBody2',
-    attaches: [new mongoose.Types.ObjectId().toHexString(), new mongoose.Types.ObjectId().toHexString()],
+    attaches: [
+      new mongoose.Types.ObjectId().toHexString(),
+      new mongoose.Types.ObjectId().toHexString(),
+    ],
     createdAt: new Date(),
     author: mockRecipient,
     chatId: new mongoose.Types.ObjectId().toHexString(),
   },
-]
+];
 
 const mockResponseMessage = {
   data: {
-    messages: mockMessages
-  }
-}
+    messages: mockMessages,
+  },
+};
 
 const mockTaskChatMeta = {
   _id: new mongoose.Types.ObjectId().toHexString(),
@@ -117,7 +121,7 @@ const mockTaskChatMeta = {
   updatedAt: new Date().toISOString(),
   watermark: new mongoose.Types.ObjectId().toHexString(),
   unreads: 1,
-}
+};
 
 const mockSystemChatMeta: SystemChatMetaInterface = {
   _id: new mongoose.Types.ObjectId().toHexString(),
@@ -130,11 +134,11 @@ const mockSystemChatMeta: SystemChatMetaInterface = {
   updatedAt: new Date().toISOString(),
   watermark: new mongoose.Types.ObjectId().toHexString(),
   unreads: 1,
-}
+};
 
 const mockVolunteerChat: VolunteerConflictChatMetaInterface = {
   _id: new mongoose.Types.ObjectId().toHexString(),
-  type: "CONFLICT_CHAT_WITH_VOLUNTEER",
+  type: 'CONFLICT_CHAT_WITH_VOLUNTEER',
   isActive: true,
   volunteer: mockVolunteer,
   id: '10',
@@ -142,11 +146,11 @@ const mockVolunteerChat: VolunteerConflictChatMetaInterface = {
   updatedAt: new Date().toISOString(),
   watermark: new mongoose.Types.ObjectId().toHexString(),
   unreads: 10,
-}
+};
 
 const mockRecipientChat: RecipientConflictChatMetaInterface = {
   _id: new mongoose.Types.ObjectId().toHexString(),
-  type: "CONFLICT_CHAT_WITH_RECIPIENT",
+  type: 'CONFLICT_CHAT_WITH_RECIPIENT',
   isActive: true,
   recipient: mockRecipient,
   id: '20',
@@ -154,7 +158,7 @@ const mockRecipientChat: RecipientConflictChatMetaInterface = {
   updatedAt: new Date().toISOString(),
   watermark: new mongoose.Types.ObjectId().toHexString(),
   unreads: 10,
-}
+};
 
 const mockConflictChats: ConflictChatsTupleMetaInterface = {
   moderator: mockAdmin,
@@ -163,19 +167,17 @@ const mockConflictChats: ConflictChatsTupleMetaInterface = {
   adminVolunteerUnreads: 10,
   adminRecipientWatermark: 'adminRecipientWatermark',
   adminRecipientUnreads: 11,
-  meta: [mockVolunteerChat, mockRecipientChat]
-}
+  meta: [mockVolunteerChat, mockRecipientChat],
+};
 
 const mockMetaArray = [mockTaskChatMeta, mockSystemChatMeta, mockVolunteerChat];
-//#endregion
+// #endregion
 
 @Injectable()
 export class ChatService {
-  constructor(
-    private readonly commandBus: CommandBus,
-    private readonly queryBus: QueryBus
-  ) {}
+  constructor(private readonly commandBus: CommandBus, private readonly queryBus: QueryBus) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async createTaskChat(metadata: TaskChatMetaInterface) {
     // const chatEntity = new ChatEntity();
 
@@ -191,20 +193,28 @@ export class ChatService {
 
     // return response;
 
+    // eslint-disable-next-line no-console
     console.log('Creating task chat');
     return mockTaskChatMeta;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async createSystemChat(metadata: SystemChatMetaInterface): Promise<SystemChatMetaInterface> {
+    // eslint-disable-next-line no-console
     console.log('Creating system chat');
     return mockSystemChatMeta;
   }
 
-  async createConflictChat(metadata: ConflictChatsTupleMetaInterface): Promise<ConflictChatsTupleMetaInterface> {
+  async createConflictChat(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    metadata: ConflictChatsTupleMetaInterface
+  ): Promise<ConflictChatsTupleMetaInterface> {
+    // eslint-disable-next-line no-console
     console.log('Creating conflict chat');
     return mockConflictChats;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async addMessage(chatId: string, message: MessageInterface) {
     // const chatEntity = new ChatEntity();
 
@@ -221,68 +231,93 @@ export class ChatService {
 
     // return response;
 
+    // eslint-disable-next-line no-console
     console.log('Adding message into chat');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getConflictChatsByAdmin(userId: ObjectId, chatQuery: wsChatPageQueryPayload) {
+    // eslint-disable-next-line no-console
     console.log('Getting conflict chats by admin');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getConflictClosedChats(chatQuery: wsChatPageQueryPayload) {
+    // eslint-disable-next-line no-console
     console.log('Getting conflict closed chats');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getOpenSystemChats(chatQuery: wsChatPageQueryPayload) {
+    // eslint-disable-next-line no-console
     console.log('Getting open system chats');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getClosedSystemChats(chatQuery: wsChatPageQueryPayload) {
+    // eslint-disable-next-line no-console
     console.log('Getting closed system chats');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getSystemChatsByUser(userId: ObjectId, chatQuery: wsChatPageQueryPayload) {
+    // eslint-disable-next-line no-console
     console.log('Getting system chats by user');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getOpenSystemChatsByAdmin(userId: ObjectId, chatQuery: wsChatPageQueryPayload) {
+    // eslint-disable-next-line no-console
     console.log('Getting open system chats by admin');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getClosedSystemChatsByAdmin(userId: ObjectId, chatQuery: wsChatPageQueryPayload) {
+    // eslint-disable-next-line no-console
     console.log('Getting closed system chats by admin');
     return mockResponseMessage;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async closeChatByTask(taskId: ObjectId) {
     // const chatEntity = new ChatEntity();
 
     // const chat = await chatEntity.findChatByParams({ taskId: taskId });
     // chat.closeChat();
 
+    // eslint-disable-next-line no-console
     console.log('Closing chat by task');
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async closeConflictChats(chatId: string) {
+    // eslint-disable-next-line no-console
     console.log('Closing conflict chats');
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async closeSystemChat(chatId: string) {
+    // eslint-disable-next-line no-console
     console.log('Closing system chat');
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getUserChatsMeta(userId: string | ObjectId) {
+    // eslint-disable-next-line no-console
     console.log('Getting user meta');
     return mockMetaArray;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getMessages(chatId: string | ObjectId, skip: number, limit?: number) {
+    // eslint-disable-next-line no-console
     console.log('Getting messages');
     return mockResponseMessage;
   }


### PR DESCRIPTION
:grey_exclamation: PR создан взамен https://github.com/ya-pomogau/backend/pull/184 :grey_exclamation:

#### В `websockets.types.ts`:
- [x] Добавила тип для новой мапы `OpenedChats`:
```ts
export type wsOpenedChatsData<T extends string> = {
  [key in T]: Array<string>;
};
```
Имя свойства - `user._id`.
В массиве - `client.id` всех сокет-подключений, на которых у пользователя открыт этот чат.

#### В `WebsocketApiGateway`:
- [x] Внедрила `QueryBus` и `CommandBus` из `nestjs/cqrs` (пока закомментировала).
- [x] Создала Map-объект `OpenedChats` вида:
- ключ: chatId;
- значение: тип `wsOpenedChatsData`; 
- [x] Вынесла в отдельный приватный метод `getConnectedUser(userId)` проверку статуса подключения пользователя. Метод ищет в Map-объекте `connectedUsers` значение по ключу user._id и возвращает найденное значение или `null` (если пользователь не подключен).
- [x] Вынесла в отдельный приватный метод `checkUserAuth(client: Socket)` проверку аутентификации пользователя. Метод возвращает объект user или `null` (если проверка аутентификации провалена).