### PR TITLE
[Hotfix] Corrected `.addMessage` & some typings

### DIFF
--- a/src/common/types/chats.types.ts
+++ b/src/common/types/chats.types.ts
@@ -8,13 +8,12 @@ import {
 import { MongooseIdAndTimestampsInterface } from './system.types';
 
 export interface MessageInterface {
-  _id: ObjectId;
-  title: string;
+  _id: ObjectId | string;
   body: string;
   attaches: string[];
-  createdAt: Date;
+  createdAt: Date | string;
   author: AnyUserInterface;
-  chatId: ObjectId;
+  chatId: ObjectId | string;
 }
 
 export const ChatTypes = {

--- a/src/common/types/chats.types.ts
+++ b/src/common/types/chats.types.ts
@@ -8,11 +8,10 @@ import {
 import { MongooseIdAndTimestampsInterface } from './system.types';
 
 export interface MessageInterface {
-  _id: ObjectId;
-  title: string;
+  _id: ObjectId | string;
   body: string;
   attaches: string[];
-  createdAt: Date;
+  createdAt: Date | string;
   author: AnyUserInterface;
   chatId: ObjectId;
 }

--- a/src/core/chat/chats.service.ts
+++ b/src/core/chat/chats.service.ts
@@ -178,7 +178,9 @@ export class ChatService {
   constructor(private readonly commandBus: CommandBus, private readonly queryBus: QueryBus) {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async createTaskChat(metadata: TaskChatMetaInterface) {
+  async createTaskChat(
+    metadata: Pick<TaskChatMetaInterface, 'type' | 'volunteer' | 'recipient' | 'taskId'>
+  ) {
     // const chatEntity = new ChatEntity();
 
     // const newChat = await chatEntity.createChat('TASK_CHAT', metadata);
@@ -194,7 +196,8 @@ export class ChatService {
     // return response;
 
     // eslint-disable-next-line no-console
-    console.log('Creating task chat');
+    console.log('Creating task chat.\nMeta:');
+    console.dir(metadata);
     return mockTaskChatMeta;
   }
 
@@ -215,7 +218,7 @@ export class ChatService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async addMessage(chatId: string, message: MessageInterface) {
+  async addMessage(chatId: string, message: Omit<MessageInterface, '_id' | 'createdAt' | 'title'>) {
     // const chatEntity = new ChatEntity();
 
     // const chat = await chatEntity.findChatByParams({ chatId: chatId });
@@ -233,7 +236,12 @@ export class ChatService {
 
     // eslint-disable-next-line no-console
     console.log('Adding message into chat');
-    return mockResponseMessage;
+    console.dir(message);
+    return {
+      ...message,
+      _id: new mongoose.Types.ObjectId().toHexString(),
+      createdAt: new Date().toISOString(),
+    } as MessageInterface;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,14 @@ import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import configuration from './config/configuration';
+import { MethodNotAllowedExceptionFilter } from './common/filters/methodNotAllowedFilter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(
     new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true })
   );
+  app.useGlobalFilters(new MethodNotAllowedExceptionFilter());
   // app.enableCors({ origin: configuration().server.cors_origins.split(',') });
   app.enableCors({ origin: '*' });
 


### PR DESCRIPTION
- [x] `ChatsService.addMessage()` now returns received message, not a hardcoded fixture.
- [x] Corrected typing for `.createTaskChat()` arguments
- [x] `_id` & `createdAt` in `MessageInterface` now also can be a string.